### PR TITLE
fix: prettierrc misnamed and misconfigured

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,18 +1,18 @@
 {
-  "arrowParens": "avoid",
-  "bracketSpacing": false,
+  "arrowParens": "always",
+  "bracketSpacing": true,
   "endOfLine": "lf",
   "htmlWhitespaceSensitivity": "css",
   "insertPragma": false,
   "jsxBracketSameLine": false,
   "jsxSingleQuote": false,
-  "printWidth": 80,
+  "printWidth": 100,
   "proseWrap": "always",
   "quoteProps": "as-needed",
   "requirePragma": false,
   "semi": false,
   "singleQuote": true,
   "tabWidth": 2,
-  "trailingComma": "all",
+  "trailingComma": "es5",
   "useTabs": false
 }


### PR DESCRIPTION
The prettierrc was misnamed, so prettier couldn't find it. Also, the
options were set differently from the apparent preferences in the code.
With these changes, the following does not modify code:

    find src -name \*.ts -print0 | xargs -0 npx prettier -w