### PR TITLE
feat: Add responseDelay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,4 +120,35 @@ setRequestHandlersByWebarchive(worker, har, {
 })
 ```
 
+### `responseDelay: 'real' | 'none' | ResponseDelayFunction`
+
+- Default: `real`
+
+Controls the mock response delay behavior.
+- __real__: Responses will be delayed based on the `time` property in the HAR
+- __none__: Responses will not be delayed
+- __ResponseDelayFunction__: Responses will be delayed by the value returned by the function 
+  - Signature: `(timeDelay: number, requestContext: Request) => number`
+  - Parameters:
+    - `timeDelay`: the value of the `time` property in the HAR, or 0 if there is no `time` property
+    - `requestContext`: the [request](https://developer.mozilla.org/en-US/docs/Web/API/Request) intercepted by Mock Service Worker
+  - Return value:
+    - The amount of time that the response should be delayed, in milliseconds. The response will not be delayed if a value <= 0 is returned
+
+```js
+setRequestHandlersByWebarchive(worker, har, {
+  responseDelay: 'none'
+})
+```
+```js
+setRequestHandlersByWebarchive(worker, har, {
+  responseDelay: (timeDelay: number, requestContext: Request) => {
+    if (requestContext.url === 'http://example.com') {
+      return timeDelay * 2
+    }
+    return 0
+  }
+})
+```
+
 [msw-install]: https://mswjs.io/docs/getting-started/install

--- a/src/__tests__/webArchiveHandlerProvider.test.ts
+++ b/src/__tests__/webArchiveHandlerProvider.test.ts
@@ -1,5 +1,6 @@
 import { server } from '../../mocks/server'
 import { setRequestHandlersByWebarchive } from '../node'
+import { ResponseDelayOption } from '../serverHandler'
 import { default as webarchiveDefinition } from '../../example/webarchive.har'
 import { default as emptyWebarchiveDefinition } from '../../example/empty-webarchive.har'
 import { default as corsExampleDefinition } from '../../example/cors-example.har'
@@ -146,5 +147,83 @@ describe('webArchiveHandlerProvider', () => {
 
     const res = await fetch('https://www.archaeology.org?query=string', { method: 'GET' })
     expect(await res.json()).toEqual({ query: 'string' })
+  })
+
+  it.each(['real', undefined, 'invalid value']) 
+    ('should use real timing when responseDelay is %o', async responseDelay => {
+    const { request, time: expectedDelay } = webarchiveDefinition.log.entries[0]
+    const { method, url: testUrl } = request
+    jest.spyOn(console, 'warn').mockImplementation(noop)
+
+    setRequestHandlersByWebarchive(server, webarchiveDefinition, {
+      quiet: false,
+      responseDelay: responseDelay as ResponseDelayOption,
+    })
+
+    await fetch(testUrl, { method })
+
+    expect(console.warn).toHaveBeenCalledWith(`Response will be delayed with ${expectedDelay}ms`)
+  })
+
+  it("should not delay when responseDelay is 'none'", async () => {
+    const { method, url: testUrl } = webarchiveDefinition.log.entries[0].request
+    jest.spyOn(console, 'warn').mockImplementation(noop)
+
+    setRequestHandlersByWebarchive(server, webarchiveDefinition, {
+      quiet: false,
+      responseDelay: 'none',
+    })
+
+    await fetch(testUrl, { method })
+
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('should support custom delay functions', async () => {
+    const { request: requestFromHar, time: delayFromHar } = webarchiveDefinition.log.entries[0]
+    const { method, url: testUrl } = requestFromHar
+    const expectedDelay = 12
+    const expectedHeaders = { testHeader: 'testHeaderValue' }
+    jest.spyOn(console, 'warn').mockImplementation(noop)
+
+    let delayFromFn: number | undefined
+    let requestFromFn: Request | undefined
+    const delayFn = jest.fn().mockImplementation((delay, request) => {
+      delayFromFn = delay
+      requestFromFn = request
+      return expectedDelay
+    })
+
+    setRequestHandlersByWebarchive(server, webarchiveDefinition, {
+      quiet: false,
+      responseDelay: delayFn,
+    })
+
+    await fetch(testUrl, { headers: expectedHeaders, method })
+
+    expect(console.warn).toHaveBeenCalledWith(`Response will be delayed with ${expectedDelay}ms`)
+    expect(delayFn).toHaveBeenCalled()
+    expect(delayFromFn).toBe(delayFromHar)
+    expect(requestFromFn?.url).toBe(testUrl)
+    expect(requestFromFn?.method).toBe(method)
+    expect(requestFromFn?.headers?.get('testHeader')).toEqual(expectedHeaders.testHeader)
+  })
+
+  it.each([0, -1])
+    ('should not delay when a custom delay function returns %s', async delay => {
+    const { method, url: testUrl } = webarchiveDefinition.log.entries[0].request
+    jest.spyOn(console, 'warn').mockImplementation(noop)
+
+    const delayFn = jest.fn().mockReturnValue(delay)
+
+    setRequestHandlersByWebarchive(server, webarchiveDefinition, {
+      quiet: false,
+      responseDelay: delayFn,
+    })
+
+    await fetch(testUrl, { method })
+
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(delayFn).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Resolves https://github.com/Tapico/tapico-msw-webarchive/issues/51

Adds a `responseDelay` option to control how mock responses are delayed. Supports `real` to use the time property from the HAR, `none` to never delay, and a function to customize the delay behavior. 

Defaults to `real` to avoid changing existing behavior